### PR TITLE
Adding return count warnings

### DIFF
--- a/pylas/errors.py
+++ b/pylas/errors.py
@@ -20,8 +20,3 @@ class LazPerfNotFound(Exception):
 
 class IncompatibleDataFormat(Exception):
     pass
-
-class LasVersionWarning(UserWarning):
-    """
-    Warnings related to incompatible values for LAS version.
-    """

--- a/pylas/errors.py
+++ b/pylas/errors.py
@@ -20,3 +20,8 @@ class LazPerfNotFound(Exception):
 
 class IncompatibleDataFormat(Exception):
     pass
+
+class LasVersionWarning(UserWarning):
+    """
+    Warnings related to incompatible values for LAS version.
+    """


### PR DESCRIPTION
Adding warnings when updating header return count bins are too high for the LAS version. Completely open to changing how the error is caught, and what to call the warning. 