### PR TITLE
Use laszip as an option  to compress

### DIFF
--- a/pylas/compression.py
+++ b/pylas/compression.py
@@ -49,11 +49,11 @@ def uncompressed_id_to_compressed(point_format_id):
     return (2 ** 7) | point_format_id
 
 
-def pylaz_decompress_buffer(compressed_buffer, point_size, point_count, laszip_vlr, parallel=True):
+def lazrs_decompress_buffer(compressed_buffer, point_size, point_count, laszip_vlr, parallel=True):
     try:
-        import pylaz
+        import lazrs
     except Exception as e:
-        raise LazError("pylaz is not installed") from e
+        raise LazError("lazrs is not installed") from e
 
     try:
         point_compressed = np.frombuffer(compressed_buffer, dtype=np.uint8)
@@ -61,30 +61,30 @@ def pylaz_decompress_buffer(compressed_buffer, point_size, point_count, laszip_v
 
         point_decompressed = np.zeros(point_count * point_size, np.uint8)
 
-        pylaz.decompress_points(point_compressed, vlr_data, point_decompressed, parallel)
-    except pylaz.PyLazError as e:
-        raise LazError("pylaz error: {}".format(e)) from e
+        lazrs.decompress_points(point_compressed, vlr_data, point_decompressed, parallel)
+    except lazrs.LazrsError as e:
+        raise LazError("lazrs error: {}".format(e)) from e
     else:
         return point_decompressed
 
 
-def pylaz_compress_points(points_data, parallel=True):
+def lazrs_compress_points(points_data, parallel=True):
     try:
-        import pylaz
+        import lazrs
     except Exception as e:
-        raise LazError("pylaz is not installed") from e
+        raise LazError("lazrs is not installed") from e
 
     try:
-        vlr = pylaz.LazVlr.new_for_compression(
+        vlr = lazrs.LazVlr.new_for_compression(
             points_data.point_format.id, points_data.point_format.num_extra_bytes)
 
-        compressed_data = pylaz.compress_points(
+        compressed_data = lazrs.compress_points(
             vlr,
             np.frombuffer(points_data.array, np.uint8),
             parallel
         )
-    except pylaz.PyLazError as e:
-        raise LazError("pylaz error: {}".format(e)) from e
+    except lazrs.LazrsError as e:
+        raise LazError("lazrs error: {}".format(e)) from e
     else:
         return compressed_data, vlr.record_data()
 

--- a/pylas/compression.py
+++ b/pylas/compression.py
@@ -48,7 +48,7 @@ def uncompressed_id_to_compressed(point_format_id):
     return (2 ** 7) | point_format_id
 
 
-def pylaz_decompress_buffer(compressed_buffer, point_size, point_count, laszip_vlr):
+def pylaz_decompress_buffer(compressed_buffer, point_size, point_count, laszip_vlr, parallel=True):
     try:
         import pylaz
     except Exception as e:
@@ -60,14 +60,14 @@ def pylaz_decompress_buffer(compressed_buffer, point_size, point_count, laszip_v
 
         point_decompressed = np.zeros(point_count * point_size, np.uint8)
 
-        pylaz.decompress_points(point_compressed, vlr_data, point_decompressed)
+        pylaz.decompress_points(point_compressed, vlr_data, point_decompressed, parallel)
     except pylaz.PyLazError as e:
         raise LazError("pylaz error: {}".format(e)) from e
     else:
         return point_decompressed
 
 
-def pylaz_compress_points(points_data):
+def pylaz_compress_points(points_data, parallel=True):
     try:
         import pylaz
     except Exception as e:
@@ -79,7 +79,8 @@ def pylaz_compress_points(points_data):
 
         compressed_data = pylaz.compress_points(
             vlr,
-            np.frombuffer(points_data.array, np.uint8)
+            np.frombuffer(points_data.array, np.uint8),
+            parallel
         )
     except pylaz.PyLazError as e:
         raise LazError("pylaz error: {}".format(e)) from e

--- a/pylas/errors.py
+++ b/pylas/errors.py
@@ -18,7 +18,11 @@ class FileVersionNotSupported(PylasError):
     pass
 
 
-class LazPerfNotFound(PylasError):
+class LazError(PylasError):
+    pass
+
+
+class LazPerfNotFound(LazError):
     pass
 
 

--- a/pylas/errors.py
+++ b/pylas/errors.py
@@ -22,9 +22,5 @@ class LazError(PylasError):
     pass
 
 
-class LazPerfNotFound(LazError):
-    pass
-
-
 class IncompatibleDataFormat(PylasError):
     pass

--- a/pylas/lasdatas/base.py
+++ b/pylas/lasdatas/base.py
@@ -9,7 +9,7 @@ from .. import errors
 from ..compression import (
     uncompressed_id_to_compressed,
     lazperf_compress_points,
-    pylaz_compress_points,
+    lazrs_compress_points,
     LasZipProcess
 )
 from ..point import record, dims, PointFormat
@@ -257,12 +257,12 @@ class LasBase(object):
 
         if do_compress:
             try:
-                compressed_points_buf, vlr_data = pylaz_compress_points(self.points_data)
+                compressed_points_buf, vlr_data = lazrs_compress_points(self.points_data)
             except errors.LazError as e:
                 try:
                     logger.error("pylaz failed to compress: {}".format(e))
                     compressed_points_buf, vlr_data = lazperf_compress_points(self.points_data)
-                except (RuntimeError, errors.LazPerfNotFound) as e:
+                except errors.LazError as e:
                     logger.error("lazperf failed to compress: {}".format(e))
                     self._compress_with_laszip_executable(out_stream)
                     return

--- a/pylas/lasdatas/base.py
+++ b/pylas/lasdatas/base.py
@@ -253,7 +253,8 @@ class LasBase(object):
         if do_compress:
             try:
                 compressed_points_buf, vlr_data = pylaz_compress_points(self.points_data)
-            except:
+            except RuntimeError as e:
+                logger.error("pylaz failed to compress: {}".format(e))
                 compressed_points_buf, vlr_data = lazperf_compress_points(self.points_data)
 
             self.vlrs.append(known.LasZipVlr(vlr_data))

--- a/pylas/lasdatas/base.py
+++ b/pylas/lasdatas/base.py
@@ -253,7 +253,7 @@ class LasBase(object):
         if do_compress:
             try:
                 compressed_points_buf, vlr_data = pylaz_compress_points(self.points_data)
-            except RuntimeError as e:
+            except errors.LazError as e:
                 logger.error("pylaz failed to compress: {}".format(e))
                 compressed_points_buf, vlr_data = lazperf_compress_points(self.points_data)
 

--- a/pylas/lasdatas/base.py
+++ b/pylas/lasdatas/base.py
@@ -6,7 +6,12 @@ import numpy as np
 from pylas import extradims
 from pylas.vlrs.known import ExtraBytesStruct, ExtraBytesVlr
 from .. import errors
-from ..compression import uncompressed_id_to_compressed, lazperf_compress_points, pylaz_compress_points
+from ..compression import (
+    uncompressed_id_to_compressed,
+    lazperf_compress_points,
+    pylaz_compress_points,
+    LasZipProcess
+)
 from ..point import record, dims, PointFormat
 from ..vlrs import known, vlrlist
 
@@ -254,9 +259,13 @@ class LasBase(object):
             try:
                 compressed_points_buf, vlr_data = pylaz_compress_points(self.points_data)
             except errors.LazError as e:
-                logger.error("pylaz failed to compress: {}".format(e))
-                compressed_points_buf, vlr_data = lazperf_compress_points(self.points_data)
-
+                try:
+                    logger.error("pylaz failed to compress: {}".format(e))
+                    compressed_points_buf, vlr_data = lazperf_compress_points(self.points_data)
+                except (RuntimeError, errors.LazPerfNotFound) as e:
+                    logger.error("lazperf failed to compress: {}".format(e))
+                    self._compress_with_laszip_executable(out_stream)
+                    return
             self.vlrs.append(known.LasZipVlr(vlr_data))
             raw_vlrs = vlrlist.RawVLRList.from_list(self.vlrs)
 
@@ -273,14 +282,13 @@ class LasBase(object):
             points_bytes = bytearray(compressed_points_buf.tobytes())
             offset_to_chunk_table = struct.unpack_from("<q", points_bytes, 0)[0]
             struct.pack_into("<q", points_bytes, 0, self.header.offset_to_point_data + offset_to_chunk_table)
-
         else:
             raw_vlrs = vlrlist.RawVLRList.from_list(self.vlrs)
             self.header.number_of_vlr = len(raw_vlrs)
             self.header.offset_to_point_data = (
                     self.header.size + raw_vlrs.total_size_in_bytes()
             )
-            points_bytes = self.points_data.raw_bytes()
+            points_bytes = self.points_data.memoryview()
 
         self.header.write_to(out_stream)
         self._raise_if_not_expected_pos(out_stream, self.header.size)
@@ -351,6 +359,22 @@ class LasBase(object):
             if do_compress is None:
                 do_compress = False
             self.write_to(destination, do_compress=do_compress)
+
+    def _compress_with_laszip_executable(self, out_stream):
+        try:
+            out_stream.fileno()
+        except OSError:
+            laszip_prc = LasZipProcess(LasZipProcess.Actions.Compress)
+            self.write_to(laszip_prc.stdin)
+            stdout_data = laszip_prc.communicate()
+            out_stream.seek(0)
+            out_stream.write(stdout_data)
+        else:
+            # The ouput is a file
+            # let laszip write directly to it, to avoid copies
+            laszip_prc = LasZipProcess(LasZipProcess.Actions.Compress, stdout=out_stream)
+            self.write_to(laszip_prc.stdin)
+            laszip_prc.wait_until_finished()
 
     def __repr__(self):
         return "<LasData({}.{}, point fmt: {}, {} points, {} vlrs)>".format(

--- a/pylas/lasreader.py
+++ b/pylas/lasreader.py
@@ -61,8 +61,8 @@ class LasReader:
 
         try:
             points = self._read_points(vlrs)
-        except (RuntimeError, errors.LazPerfNotFound) as e:
-            logger.error("LazPerf failed to decompress ({}), trying laszip.".format(e))
+        except errors.LazError as e:
+            logger.error("error when decompressing {}, trying laszip".format(e))
             decompressed_stream = self._decompress_with_laszip_executable()
             self.__init__(decompressed_stream)
             return self.read()

--- a/pylas/lasreader.py
+++ b/pylas/lasreader.py
@@ -1,9 +1,10 @@
 import io
 import logging
+import os
 import struct
 
 from . import headers, errors, evlrs
-from .compression import laszip_decompress, pylaz_decompress_buffer, lazperf_decompress_buffer
+from .compression import pylaz_decompress_buffer, lazperf_decompress_buffer, LasZipProcess
 from .lasdatas import las14, las12
 from .point import record, PointFormat
 from .vlrs import rawvlr
@@ -62,8 +63,8 @@ class LasReader:
             points = self._read_points(vlrs)
         except (RuntimeError, errors.LazPerfNotFound) as e:
             logger.error("LazPerf failed to decompress ({}), trying laszip.".format(e))
-            self.stream.seek(self.start_pos)
-            self.__init__(io.BytesIO(laszip_decompress(self.stream)))
+            decompressed_stream = self._decompress_with_laszip_executable()
+            self.__init__(decompressed_stream)
             return self.read()
 
         if points.point_format.has_waveform_packet:
@@ -154,6 +155,29 @@ class LasReader:
             self.header.point_count
         )
         return points
+
+    def _decompress_with_laszip_executable(self):
+        self.stream.seek(self.start_pos)
+        try:
+            fileno = self.stream.fileno()
+        except OSError:
+            laszip_prc = LasZipProcess(LasZipProcess.Actions.Decompress)
+            laszip_prc.stdin.write(self.stream.read())
+            stdout_data = laszip_prc.communicate()
+            new_source = io.BytesIO(stdout_data)
+        else:
+            # The input is a file
+            # let laszip read directly from it to avoid copying it
+            # the os seek is need as the stream used is probably a buffered reader
+            # so the position of the file handle has to be reset also
+            # https://stackoverflow.com/questions/22417010/subprocess-popen-stdin-read-file
+            os.lseek(fileno, self.start_pos, os.SEEK_SET)
+            laszip_prc = LasZipProcess(LasZipProcess.Actions.Decompress, stdin=self.stream)
+            stdout_data = laszip_prc.communicate()
+            new_source = io.BytesIO(stdout_data)
+
+        return new_source
+
 
     def _read_internal_waveform_packet(self):
         """ reads and returns the waveform vlr header, waveform record

--- a/pylas/lasreader.py
+++ b/pylas/lasreader.py
@@ -4,7 +4,7 @@ import os
 import struct
 
 from . import headers, errors, evlrs
-from .compression import pylaz_decompress_buffer, lazperf_decompress_buffer, LasZipProcess
+from .compression import lazrs_decompress_buffer, lazperf_decompress_buffer, LasZipProcess
 from .lasdatas import las14, las12
 from .point import record, PointFormat
 from .vlrs import rawvlr
@@ -132,14 +132,14 @@ class LasReader:
         struct.pack_into("<q", points_data, 0, offset_to_chunk_table)
 
         try:
-            decompressed_points = pylaz_decompress_buffer(
+            decompressed_points = lazrs_decompress_buffer(
                 points_data,
                 point_format.dtype.itemsize,
                 self.header.point_count,
                 laszip_vlr
             )
         except errors.LazError as e:
-            logger.error("pylaz failed to decompress points: {}".format(e))
+            logger.error("lazrs failed to decompress points: {}".format(e))
             points_data = points_data[8:]
 
             decompressed_points = lazperf_decompress_buffer(

--- a/pylas/point/record.py
+++ b/pylas/point/record.py
@@ -10,7 +10,7 @@ import numpy as np
 
 from . import dims, packing
 from .. import errors
-from ..compression import decompress_buffer
+from ..compression import lazperf_decompress_buffer
 from ..point import PointFormat
 
 logger = logging.getLogger(__name__)
@@ -75,13 +75,6 @@ class IPointRecord(ABC):
     @classmethod
     @abstractmethod
     def from_stream(cls, stream, point_format_id, count):
-        pass
-
-    @classmethod
-    @abstractmethod
-    def from_compressed_buffer(
-            cls, compressed_buffer, point_format_id, count, laszip_vlr
-    ):
         pass
 
     @classmethod
@@ -287,17 +280,6 @@ class PackedPointRecord(PointRecord):
         data = np.frombuffer(buffer, dtype=points_dtype, offset=offset, count=count)
 
         return cls(data, point_format)
-
-    @classmethod
-    def from_compressed_buffer(cls, compressed_buffer, point_format, count, laszip_vlr):
-        """  Construct the point record by reading and decompressing the points data from
-        the input buffer
-        """
-        point_dtype = point_format.dtype
-        uncompressed = decompress_buffer(
-            compressed_buffer, point_dtype, count, laszip_vlr
-        )
-        return cls(uncompressed, point_format)
 
     def write_to(self, out):
         """ Writes the points to the output stream"""

--- a/pylas/point/record.py
+++ b/pylas/point/record.py
@@ -135,6 +135,9 @@ class PointRecord(IPointRecord):
         self.array = np.zeros_like(old_array, dtype=self.point_format.dtype)
         self.copy_fields_from(old_array)
 
+    def memoryview(self):
+        return memoryview(self.array)
+
     def raw_bytes(self):
         return self.array.tobytes()
 


### PR DESCRIPTION
 Try using laszip executable as the last option to compress data.

Also reduce memory used when writing by using a memoryview of the numpy array instead of copying the bytes to then write them.

Should be merged after #9 

This also needs to be tested because I remember having tried to use laszip executable to compress data but the output files where corrupted 🤔 