### PR TITLE
Handle pathlib Path objects

### DIFF
--- a/pylas/lib.py
+++ b/pylas/lib.py
@@ -5,6 +5,7 @@ import copy
 import io
 import logging
 import os
+from pathlib import Path
 from typing import Union
 
 import numpy as np
@@ -97,7 +98,7 @@ def open_las(
                 "do_compress argument is not used when opening in read mode, "
                 "did you meant to open in write mode ?"
             )
-        if isinstance(source, str):
+        if isinstance(source, (str, Path)):
             stream = open(source, mode="rb", closefd=closefd)
         elif isinstance(source, bytes):
             stream = io.BytesIO(source)
@@ -108,7 +109,7 @@ def open_las(
         if header is None:
             raise ValueError("A header is needed when opening a file for writing")
 
-        if isinstance(source, str):
+        if isinstance(source, (str, Path)):
             if do_compress is None:
                 do_compress = os.path.splitext(source)[1].lower() == ".laz"
             stream = open(source, mode="wb+", closefd=closefd)
@@ -127,7 +128,7 @@ def open_las(
             closefd=closefd,
         )
     elif mode == "a":
-        if isinstance(source, str):
+        if isinstance(source, (str, Path)):
             stream = open(source, mode="rb+", closefd=closefd)
         elif isinstance(source, bytes):
             stream = io.BytesIO(source)

--- a/pylastests/test_common.py
+++ b/pylastests/test_common.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 
 import numpy as np
 import pytest
@@ -6,13 +7,13 @@ import pytest
 import pylas
 from pylas.lib import write_then_read_again
 
-simple_las = os.path.dirname(__file__) + "/" + "simple.las"
-simple_laz = os.path.dirname(__file__) + "/" + "simple.laz"
-vegetation1_3_las = os.path.dirname(__file__) + "/vegetation_1_3.las"
-test1_4_las = os.path.dirname(__file__) + "/" + "test1_4.las"
-extra_bytes_las = os.path.dirname(__file__) + "/extrabytes.las"
-extra_bytes_laz = os.path.dirname(__file__) + "/extra.laz"
-plane_laz = os.path.dirname(__file__) + "/plane.laz"
+simple_las = Path(__file__).parent / "simple.las"
+simple_laz = Path(__file__).parent / "simple.laz"
+vegetation1_3_las = Path(__file__).parent / "vegetation_1_3.las"
+test1_4_las = Path(__file__).parent / "test1_4.las"
+extra_bytes_las = Path(__file__).parent / "extrabytes.las"
+extra_bytes_laz = Path(__file__).parent / "extra.laz"
+plane_laz = Path(__file__).parent / "plane.laz"
 
 if not pylas.LazBackend.detect_available():
     do_compression = [False]


### PR DESCRIPTION
Thank you for this library! I really like how clean and effective it is compared to alternatives.

While testing it, I found that it wouldn't handle pathlib's `Path` objects. I use them quite a bit instead of manipulating raw strings for paths. I thought it would be a simple addition.