### PR TITLE
Fix arg conversion for ufunc & array function

### DIFF
--- a/pylastests/conftest.py
+++ b/pylastests/conftest.py
@@ -88,7 +88,7 @@ def all_las_file_path():
 def mmapped_file_path(tmp_path):
     import shutil
     copied_file = shutil.copy(SIMPLE_LAS_FILE_PATH, tmp_path)
-    return copied_file
+    yield copied_file
 
 
 

--- a/pylastests/test_mmap.py
+++ b/pylastests/test_mmap.py
@@ -1,5 +1,14 @@
+import numpy as np
+
 import pylas
 
 
 def test_mmap(mmapped_file_path):
-    pylas.mmap(mmapped_file_path)
+    with pylas.mmap(mmapped_file_path) as las:
+        las.classification[:] = 25
+        assert np.all(las.classification == 25)
+
+    las = pylas.read(mmapped_file_path)
+    assert np.all(las.classification == 25)
+
+


### PR DESCRIPTION
We convert all ScaledArrayView or SubFieldView to numpy array
so that the true numpy fn can be called on them.

The problem was that some args were list of SubFieldView/ScaledArrayView
and were not converted. This commit fixes that

Small enhancement to the mmap test