### PR TITLE
Make do_compress optional if a LazBackend is provided

### DIFF
--- a/pylas/lasappender.py
+++ b/pylas/lasappender.py
@@ -26,15 +26,14 @@ class LasAppender:
     def __init__(
         self,
         dest: BinaryIO,
-        laz_backend: Union[LazBackend, Iterable[LazBackend]] = (
-            LazBackend.LazrsParallel,
-            LazBackend.Lazrs,
-        ),
+        laz_backend: Optional[Union[LazBackend, Iterable[LazBackend]]] = None,
         closefd: bool = True,
     ) -> None:
         if not dest.seekable():
             raise TypeError("Expected the 'dest' to be a seekable file object")
         header = LasHeader.read_from(dest)
+        if laz_backend is None:
+            laz_backend = LazBackend.detect_available()
 
         self.dest = dest
         self.header = header

--- a/pylas/lasdata.py
+++ b/pylas/lasdata.py
@@ -171,7 +171,7 @@ class LasData:
     def write(
         self,
         destination: str,
-        laz_backend: Union[LazBackend, Sequence[LazBackend]] = ...,
+        laz_backend: Optional[Union[LazBackend, Sequence[LazBackend]]] = ...,
     ) -> None:
         ...
 
@@ -180,13 +180,11 @@ class LasData:
         self,
         destination: BinaryIO,
         do_compress: Optional[bool] = ...,
-        laz_backend: Union[LazBackend, Sequence[LazBackend]] = ...,
+        laz_backend: Optional[Union[LazBackend, Sequence[LazBackend]]] = ...,
     ) -> None:
         ...
 
-    def write(
-        self, destination, do_compress=None, laz_backend=LazBackend.detect_available()
-    ):
+    def write(self, destination, do_compress=None, laz_backend=None):
         """Writes to a stream or file
 
         .. note::
@@ -215,8 +213,6 @@ class LasData:
             with open(destination, mode="wb+") as out:
                 self._write_to(out, do_compress=do_compress, laz_backend=laz_backend)
         else:
-            if do_compress is None:
-                do_compress = False
             self._write_to(
                 destination, do_compress=do_compress, laz_backend=laz_backend
             )
@@ -224,10 +220,8 @@ class LasData:
     def _write_to(
         self,
         out_stream: BinaryIO,
-        do_compress: bool = False,
-        laz_backend: Union[
-            LazBackend, Sequence[LazBackend]
-        ] = LazBackend.detect_available(),
+        do_compress: Optional[bool] = None,
+        laz_backend: Optional[Union[LazBackend, Sequence[LazBackend]]] = None,
     ) -> None:
         with LasWriter(
             out_stream,

--- a/pylas/lasmmap.py
+++ b/pylas/lasmmap.py
@@ -1,11 +1,10 @@
 import io
 import mmap
 
-from . import lasreader, lasdata
+from . import lasdata
 from .header import LasHeader
-from .point import PointFormat, record
+from .point import record
 from .typehints import PathLike
-from .vlrs import vlrlist
 
 WHOLE_FILE = 0
 

--- a/pylas/lasreader.py
+++ b/pylas/lasreader.py
@@ -31,11 +31,11 @@ class LasReader:
         self,
         source: BinaryIO,
         closefd: bool = True,
-        laz_backend: Union[
-            LazBackend, Iterable[LazBackend]
-        ] = LazBackend.detect_available(),
+        laz_backend: Optional[Union[LazBackend, Iterable[LazBackend]]] = None,
     ):
         self.closefd = closefd
+        if LazBackend is not None:
+            laz_backend = LazBackend.detect_available()
         self.laz_backend = laz_backend
         self.header = LasHeader.read_from(source)
 

--- a/pylas/lib.py
+++ b/pylas/lib.py
@@ -25,7 +25,7 @@ def open_las(
     source,
     mode="r",
     closefd=True,
-    laz_backend=LazBackend.detect_available(),
+    laz_backend=None,
     header=None,
     do_compress=None,
 ) -> Union[LasReader, LasWriter, LasAppender]:
@@ -81,6 +81,7 @@ def open_las(
 
     do_compress: optional, bool, only meaningful in writing mode:
         - None (default) guess if compression is needed using the file extension
+        or if a laz_backend was explicitely provided
         - True compresses the file
         - False do not compress the file
 
@@ -120,8 +121,7 @@ def open_las(
         else:
             assert source.seekable()
             stream = source
-        if do_compress is None:
-            do_compress = False
+
         return LasWriter(
             stream,
             header=header,
@@ -139,7 +139,7 @@ def open_las(
         return LasAppender(stream, closefd=closefd, laz_backend=laz_backend)
 
     else:
-        raise ValueError("Unknown mode '{}'".format(mode))
+        raise ValueError(f"Unknown mode '{mode}'")
 
 
 def read_las(source, closefd=True, laz_backend=LazBackend.detect_available()):
@@ -182,7 +182,7 @@ def mmap_las(filename):
 def create_las(
     *,
     point_format: Optional[Union[int, PointFormat]] = None,
-    file_version: Optional[Union[str, Version]] = None
+    file_version: Optional[Union[str, Version]] = None,
 ):
     """Function to create a new empty las data object
 

--- a/pylastests/test_creation.py
+++ b/pylastests/test_creation.py
@@ -1,3 +1,5 @@
+import io
+
 import numpy as np
 import pytest
 
@@ -139,3 +141,13 @@ def test_create_fmt_6(file1_4):
         assert np.allclose(new[dim_name], file1_4[dim_name]), "{} not equal".format(
             dim_name
         )
+
+
+@pytest.mark.parametrize("laz_backend", (None,) + pylas.LazBackend.detect_available())
+def test_writing_empty_file(laz_backend):
+    las = pylas.create()
+    with io.BytesIO() as out:
+        if laz_backend is None:
+            las.write(out)
+        else:
+            las.write(out, laz_backend=laz_backend)


### PR DESCRIPTION
If a laz_backend is provided to the LasWriter (or pylas.open)
then it is not mandatory to also provide the do_compress parameter.

If laz_backend is provided and do_compress is None -> data will
be compressed.

If laz_backend is provided and do_compress is False -> data will not
be compressed

small change to avoid redundancy